### PR TITLE
pip friendly version of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,14 @@ def setup_package():
     setup(name = 'SimCADO',
           version = VERSION,
           description = "MICADO Instrument simulator",
-          author = "Kieran Leschinski, Oliver Czoske",
+          author = "Kieran Leschinski, Oliver Czoske, Miguel Verdugo",
           author_email = """kieran.leschinski@unive.ac.at,
                             oliver.czoske@univie.ac.at""",
           url = "http://homepage.univie.ac.at/kieran.leschinski/",
-          package_dir={'simcado': '.'},
+          license="MIT",
+          package_dir={'simcado': 'simcado'},
           packages=['simcado'],
-          package_data = {'simcado': ['data/*']},
+          package_data = {'simcado': ['data/default.config']},
           )
 
 


### PR DESCRIPTION
- it should be now possible to download using "pip install -v git+https://github.com/astronomyk/SimCADO/SimCADO"
- it only downloads default.config from the data directory